### PR TITLE
add auto trust

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,14 @@
 import {
   proxyServer as ProxyServer,
-  isRootCAFileExists,
-  generateRootCA,
 } from 'dora-anyproxy';
 import getRule from './getRule';
-
-if (!isRootCAFileExists()) generateRootCA();
 
 export default {
   'name': 'proxy',
   'server.before'() {
     this.set('__server_listen_log', false);
   },
-  'server.after'() {
+  'middleware.before'() {
     const { log, query } = this;
     log.debug(`query: ${JSON.stringify(query)}`);
     const port = query && query.port || 8989;
@@ -21,6 +17,7 @@ export default {
       port,
       hostname: 'localhost',
       rule: getRule(this),
+      autoTrust: true,
     });
     proxyServer.on('finish', (err) => {
       if (err) {


### PR DESCRIPTION
1. 改为 middleware.before ，在 webpack-server 启动前进行 proxy 的相关初始化（比如生成证书和让用户输入密码信认），避免 webpack 启动后，会让屏幕日志乱掉。
2. 把生成证书和信任过程放到 ProxyServer 里构造函数里。当所有东西都 ok 后，会通过 `finish` 事件返回。
