### PR TITLE
fix cors Json Request

### DIFF
--- a/src/rule.js
+++ b/src/rule.js
@@ -175,6 +175,9 @@ export default function(args) {
       return {
         ...header,
         'access-control-allow-origin': '*',
+        'access-control-allow-headers':'Origin, X-Requested-With, Content-Type, Accept,Content-Range, Content-Disposition, Content-Description,Set-Cookie,, Access-Control-Request-Method, Access-Control-Request-Headers,Authorization,Authentication',
+		    'access-control-allow-methods':'GET,POST,PUT,DELETE,PATCH,HEAD,OPTIONS',
+		    'access-control-expose-headers':'Set-Cookie,Authorization,Authentication' 
       };
     },
 


### PR DESCRIPTION
跨域请求json格式数据的时候出现
Request header field content-type is not allowed by Access-Control-Allow-Headers in preflight response
