### PR TITLE
fix Forward with subPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dora-plugin-proxy",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/dora-js/dora-plugin-proxy"

--- a/src/rule.js
+++ b/src/rule.js
@@ -118,7 +118,7 @@ export default function(args) {
           if (proxyConfig.hasOwnProperty(pattern)) {
             const subPath = getSubPath(option, pattern);
             if (subPath) {
-              retPath = retPath.replace(RegExp(pattern), '/' + subPath);
+              retPath = winPath(join(proxyConfig(pattern), subPath))
             }
           }
         }


### PR DESCRIPTION
修复类似如下加上请求方法的规则下，路径替换错误的问题

```
'GET /someDir/(.*)': 'https://g.alicdn.com/tb-page/taobao-home/',
```
